### PR TITLE
Display git SHA in the meta tag if it exists

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -35,7 +35,7 @@ action "Login into Docker Hub" {
 action "Build a Docker container" {
   uses = "actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108"
   needs = ["If master branch"]
-  args = "build -t base ."
+  args = "build -t base --build-arg GITHUB_SHA_ARG=$GITHUB_SHA ."
 }
 
 action "Tag :latest" {

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ LABEL maintainer="paul.craig@cds-snc.ca"
 ENV PORT=80
 ENV API_URL="https://holidays-canada.azurewebsites.net"
 
+ARG GITHUB_SHA_ARG
+ENV GITHUB_SHA=$GITHUB_SHA_ARG
+
 WORKDIR /app
 COPY . .
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,10 @@
 module.exports = {
+  serverRuntimeConfig: {
+    // Will only be available on the server side
+    githubSha: process.env.GITHUB_SHA || false,
+  },
   publicRuntimeConfig: {
+    // Will be available on both server and client
     apiUrl: process.env.API_URL || 'https://holidays-canada.azurewebsites.net',
   },
 }

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,5 +1,5 @@
 import Document, { Head, Main, NextScript } from 'next/document'
-import apiUrl from '../utils/apiUrl'
+import { apiUrl, githubSha } from '../utils/envVars'
 
 export default class MyDocument extends Document {
   static async getInitialProps(ctx) {
@@ -16,12 +16,9 @@ export default class MyDocument extends Document {
             rel="stylesheet"
           />
           {process.env.GITHUB_SHA ? (
-            <meta
-              name="keywords"
-              content={`GITHUB_SHA=${process.env.GITHUB_SHA}`}
-            />
+            <meta name="keywords" content={`GITHUB_SHA=${githubSha}`} />
           ) : null}
-          <meta name="keywords" content={`api_url=${apiUrl}`} />
+          <meta name="keywords" content={`API_URL=${apiUrl}`} />
         </Head>
         <body>
           <Main />

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -15,6 +15,12 @@ export default class MyDocument extends Document {
             href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:400,500"
             rel="stylesheet"
           />
+          {process.env.GITHUB_SHA ? (
+            <meta
+              name="keywords"
+              content={`GITHUB_SHA=${process.env.GITHUB_SHA}`}
+            />
+          ) : null}
           <meta name="keywords" content={`api_url=${apiUrl}`} />
         </Head>
         <body>

--- a/pages/federal.js
+++ b/pages/federal.js
@@ -6,7 +6,7 @@ import Highlight from '../components/Highlight'
 import BottomLink from '../components/BottomLink'
 import { relativeDate } from '../utils/dates.js'
 import { space2Nbsp } from '../utils/strings.js'
-import apiUrl from '../utils/apiUrl'
+import { apiUrl } from '../utils/envVars'
 
 const getNextHoliday = holidays => {
   const today = new Date()

--- a/pages/provinces.js
+++ b/pages/provinces.js
@@ -3,7 +3,7 @@ import fetch from 'isomorphic-unfetch'
 import Layout from '../components/Layout'
 import ProvinceFound from '../components/ProvinceFound'
 import ProvinceNotFound from '../components/ProvinceNotFound'
-import apiUrl from '../utils/apiUrl'
+import { apiUrl } from '../utils/envVars'
 
 const Provinces = ({ data, province }) => (
   <Layout

--- a/utils/apiUrl.js
+++ b/utils/apiUrl.js
@@ -1,5 +1,0 @@
-import getConfig from 'next/config'
-const { publicRuntimeConfig } = getConfig()
-
-// remove possible trailing slash from API_URL env var
-export default publicRuntimeConfig.apiUrl.replace(/\/$/, '')

--- a/utils/envVars.js
+++ b/utils/envVars.js
@@ -1,0 +1,7 @@
+import getConfig from 'next/config'
+const { serverRuntimeConfig, publicRuntimeConfig } = getConfig()
+
+// remove possible trailing slash from API_URL env var
+export const apiUrl = publicRuntimeConfig.apiUrl.replace(/\/$/, '')
+
+export const githubSha = serverRuntimeConfig.githubSha


### PR DESCRIPTION
This will mean that we can keep track of what build is actually running after its deployed.