### PR TITLE
Only add secure headers in production

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const express = require('express')
 const next = require('next')
 const helmet = require('helmet')
 const LRUCache = require('lru-cache')
+const csp = require('./utils/csp')
 
 const dev = process.env.NODE_ENV !== 'production'
 const app = next({ dev })
@@ -22,24 +23,13 @@ app
   .prepare()
   .then(() => {
     const server = express()
-    server
-      .use(helmet())
-      .use(
-        helmet.contentSecurityPolicy({
-          directives: {
-            defaultSrc: ["'self'"],
-            fontSrc: ["'self'", 'https://fonts.gstatic.com'],
-            imgSrc: ["'self'", 'https://www.google-analytics.com'],
-            scriptSrc: ["'self'", 'https://www.google-analytics.com'],
-            styleSrc: [
-              "'self'",
-              'https://fonts.googleapis.com',
-              "'unsafe-inline'",
-            ],
-          },
-        }),
-      )
-      .disable('x-powered-by')
+
+    if (!dev) {
+      server
+        .use(helmet())
+        .use(helmet.contentSecurityPolicy({ directives: csp }))
+        .disable('x-powered-by')
+    }
 
     server.get('/provinces', (req, res) => {
       res.redirect('/')

--- a/utils/csp.js
+++ b/utils/csp.js
@@ -1,0 +1,7 @@
+module.exports = {
+  defaultSrc: ["'self'"],
+  fontSrc: ["'self'", 'https://fonts.gstatic.com'],
+  imgSrc: ["'self'", 'https://www.google-analytics.com'],
+  scriptSrc: ["'self'", 'https://www.google-analytics.com'],
+  styleSrc: ["'self'", 'https://fonts.googleapis.com', "'unsafe-inline'"],
+}


### PR DESCRIPTION
I was getting console errors because of our content security policy when running in dev mode. Since we don't need the content security policy in dev mode, let's only set the headers in the production build.