### PR TITLE
Add error page

### DIFF
--- a/pages/_error.js
+++ b/pages/_error.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Layout from '../components/Layout'
+import BottomLink from '../components/BottomLink'
+
+class Error extends React.Component {
+  static getInitialProps({ res, err, asPath }) {
+    const statusCode = res ? res.statusCode : err ? err.statusCode : null
+    return { statusCode, asPath }
+  }
+
+  getStatusCodeMessage(statusCode) {
+    const firstDigit = Math.floor(statusCode / 100)
+
+    if (firstDigit == 4) {
+      return <p>omg, what were u expecting??</p>
+    } else if (firstDigit == 5) {
+      return <p>sorry, i think my fault.</p>
+    }
+
+    return <p>yikes, bad luck.</p>
+  }
+
+  render() {
+    return (
+      <Layout title={`${this.props.statusCode} error`}>
+        <h1>
+          {this.props.statusCode}{' '}
+          <span role="img" aria-label="Exploding head">
+            🤯
+          </span>
+        </h1>
+
+        {this.props.statusCode ? (
+          this.getStatusCodeMessage(this.props.statusCode)
+        ) : (
+          <p>
+            sorry, maybe <a href={this.props.asPath}>refresh</a>??
+          </p>
+        )}
+        <BottomLink href={'/'} linkText={'Let’s start over.'} />
+      </Layout>
+    )
+  }
+}
+
+Error.propTypes = {
+  statusCode: PropTypes.number,
+  asPath: PropTypes.string,
+}
+
+export default Error

--- a/utils/csp.js
+++ b/utils/csp.js
@@ -1,4 +1,8 @@
+const config = require('../next.config.js')
+const apiUrl = config.publicRuntimeConfig.apiUrl.replace(/\/$/, '')
+
 module.exports = {
+  connectSrc: ["'self'", apiUrl],
   defaultSrc: ["'self'"],
   fontSrc: ["'self'", 'https://fonts.gstatic.com'],
   imgSrc: ["'self'", 'https://www.google-analytics.com'],


### PR DESCRIPTION
Currently, error pages (404, 500, etc) have just been the default Next error page.

Added a custom error page so that the app is more internally cohesive.

Also, added the `API_URL` to [the `connectSrc` in the Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src) after seeing an error in the browser.